### PR TITLE
Flag `ignore-header-prefix` added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v0.1.0
+
+### Added
+
+- Flag `--ignore-header-prefix` for incoming webhook headers ignoring (by prefix)
+
 ## v0.0.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ All supported image tags [can be found here][link_docker_tags].
 
 ### Additional configuration
 
+All supported `serve` command flags can be found by running `docker run --rm -t tarampampam/webhook-tester serve -h`.
+
 #### Pusher.com
 
 For incoming webhook notifications without index page refreshing, you can setup `pusher.com` as websocket provider. For this - [register new app](https://dashboard.pusher.com/channels) and start serving with following arguments: `./webhook-tester serve ... --pusher-app-id=YOUR_APP_ID --pusher-key=YOUR_KEY --pusher-secret=YOUR_SECRET --pusher-cluster=YOUR_CLUSTER`.

--- a/cmd/serve/command.go
+++ b/cmd/serve/command.go
@@ -36,20 +36,21 @@ type (
 
 // Command is a `serve` command.
 type Command struct {
-	Address       address   `required:"true" long:"listen" env:"LISTEN_ADDR" default:"0.0.0.0" description:"IP address to listen on"`                //nolint:lll
-	Port          port      `required:"true" long:"port" env:"LISTEN_PORT" default:"8080" description:"TCP port number"`                             //nolint:lll
-	PublicDir     publicDir `required:"true" long:"public" env:"PUBLIC_DIR" default:"./public" description:"Directory with public assets"`           //nolint:lll
-	MaxRequests   uint16    `required:"true" long:"max-requests" default:"128" env:"MAX_REQUESTS" description:"Maximum stored requests per session"` //nolint:lll
-	SessionTTLSec uint32    `required:"true" long:"session-ttl" default:"604800" env:"SESSION_TTL" description:"Session lifetime (in seconds)"`      //nolint:lll
-	RedisHost     string    `required:"true" long:"redis-host" env:"REDIS_HOST" description:"Redis server hostname or IP address"`                   //nolint:lll
-	RedisPort     port      `required:"true" long:"redis-port" default:"6379" env:"REDIS_PORT" description:"Redis server TCP port number"`           //nolint:lll
-	RedisPass     string    `long:"redis-password" default:"" env:"REDIS_PASSWORD" description:"Redis server password (optional)"`                   //nolint:lll
-	RedisDBNum    uint16    `required:"true" long:"redis-db-num" default:"1" env:"REDIS_DB_NUM" description:"Redis database number"`                 //nolint:lll
-	RedisMaxConn  uint16    `required:"true" long:"redis-max-conn" default:"10" env:"REDIS_MAX_CONN" description:"Maximum redis connections"`        //nolint:lll
-	PusherAppID   string    `long:"pusher-app-id" env:"PUSHER_APP_ID" description:"Pusher application ID"`
-	PusherKey     string    `long:"pusher-key" env:"PUSHER_KEY" description:"Pusher key"`
-	PusherSecret  string    `long:"pusher-secret" env:"PUSHER_SECRET" description:"Pusher secret"`
-	PusherCluster string    `long:"pusher-cluster" default:"eu" env:"PUSHER_CLUSTER" description:"Pusher cluster"`
+	Address            address   `required:"true" long:"listen" env:"LISTEN_ADDR" default:"0.0.0.0" description:"IP address to listen on"`                 //nolint:lll
+	Port               port      `required:"true" long:"port" env:"LISTEN_PORT" default:"8080" description:"TCP port number"`                              //nolint:lll
+	PublicDir          publicDir `required:"true" long:"public" env:"PUBLIC_DIR" default:"./public" description:"Directory with public assets"`            //nolint:lll
+	MaxRequests        uint16    `required:"true" long:"max-requests" default:"128" env:"MAX_REQUESTS" description:"Maximum stored requests per session"`  //nolint:lll
+	SessionTTLSec      uint32    `required:"true" long:"session-ttl" default:"604800" env:"SESSION_TTL" description:"Session lifetime (in seconds)"`       //nolint:lll
+	IgnoreHeaderPrefix []string  `long:"ignore-header-prefix" description:"Ignore incoming webhook header prefix, case insensitive (like 'X-Forwarded-')"` //nolint:lll
+	RedisHost          string    `required:"true" long:"redis-host" env:"REDIS_HOST" description:"Redis server hostname or IP address"`                    //nolint:lll
+	RedisPort          port      `required:"true" long:"redis-port" default:"6379" env:"REDIS_PORT" description:"Redis server TCP port number"`            //nolint:lll
+	RedisPass          string    `long:"redis-password" default:"" env:"REDIS_PASSWORD" description:"Redis server password (optional)"`                    //nolint:lll
+	RedisDBNum         uint16    `required:"true" long:"redis-db-num" default:"1" env:"REDIS_DB_NUM" description:"Redis database number"`                  //nolint:lll
+	RedisMaxConn       uint16    `required:"true" long:"redis-max-conn" default:"10" env:"REDIS_MAX_CONN" description:"Maximum redis connections"`         //nolint:lll
+	PusherAppID        string    `long:"pusher-app-id" env:"PUSHER_APP_ID" description:"Pusher application ID"`
+	PusherKey          string    `long:"pusher-key" env:"PUSHER_KEY" description:"Pusher key"`
+	PusherSecret       string    `long:"pusher-secret" env:"PUSHER_SECRET" description:"Pusher secret"`
+	PusherCluster      string    `long:"pusher-cluster" default:"eu" env:"PUSHER_CLUSTER" description:"Pusher cluster"`
 }
 
 // Convert struct into string representation.
@@ -131,10 +132,11 @@ func (cmd *Command) Execute(_ []string) error {
 
 func (cmd *Command) getAppSettings() *settings.AppSettings {
 	return &settings.AppSettings{
-		MaxRequests:   cmd.MaxRequests,
-		SessionTTL:    time.Second * time.Duration(cmd.SessionTTLSec),
-		PusherKey:     cmd.PusherKey,
-		PusherCluster: cmd.PusherCluster,
+		MaxRequests:          cmd.MaxRequests,
+		SessionTTL:           time.Second * time.Duration(cmd.SessionTTLSec),
+		PusherKey:            cmd.PusherKey,
+		PusherCluster:        cmd.PusherCluster,
+		IgnoreHeaderPrefixes: cmd.IgnoreHeaderPrefix,
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     <<: *app-service
     ports:
       - '8082:8080/tcp' # Open <http://127.0.0.1:8082>
-    command: go run . serve --port 8080 --redis-host redis --max-requests 12
+    command: go run . serve --port 8080 --redis-host redis --max-requests 12 --ignore-header-prefix foo
 
   redis:
     image: redis:6.0.5-alpine # Image page: <https://hub.docker.com/_/redis>

--- a/http/routes.go
+++ b/http/routes.go
@@ -116,21 +116,20 @@ func (s *Server) registerWebHookHandlers() {
 
 	webhookRouter.Use(AllowCORSMiddleware)
 
+	handler := webhook.NewHandler(s.appSettings, s.storage, s.broadcaster)
+
 	webhookRouter.
-		Handle("/{sessionUUID:"+uuidPattern+"}", webhook.NewHandler(s.storage, s.broadcaster)).
+		Handle("/{sessionUUID:"+uuidPattern+"}", handler).
 		Methods(allowedMethods...).
 		Name("webhook")
 
 	webhookRouter.
-		Handle(
-			"/{sessionUUID:"+uuidPattern+"}/{statusCode:[1-5][0-9][0-9]}",
-			webhook.NewHandler(s.storage, s.broadcaster),
-		).
+		Handle("/{sessionUUID:"+uuidPattern+"}/{statusCode:[1-5][0-9][0-9]}", handler).
 		Methods(allowedMethods...).
 		Name("webhook_with_status_code")
 
 	webhookRouter.
-		Handle("/{sessionUUID:"+uuidPattern+"}/{any:.*}", webhook.NewHandler(s.storage, s.broadcaster)).
+		Handle("/{sessionUUID:"+uuidPattern+"}/{any:.*}", handler).
 		Methods(allowedMethods...).
 		Name("webhook_any")
 }

--- a/http/webhook/handler_test.go
+++ b/http/webhook/handler_test.go
@@ -1,9 +1,148 @@
 package webhook
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+	"webhook-tester/broadcast"
+	nullBroadcast "webhook-tester/broadcast/null"
+	"webhook-tester/settings"
+	"webhook-tester/storage"
+	nullStorage "webhook-tester/storage/null"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHandler_ServeHTTP(t *testing.T) {
-	t.Skip("Not implemented yet")
+	t.Parallel()
+
+	var cases = []struct {
+		name        string
+		giveBody    io.Reader
+		giveReqVars map[string]string
+		setUp       func(s *nullStorage.Storage)
+		checkResult func(t *testing.T, rr *httptest.ResponseRecorder, b *nullBroadcast.Broadcaster)
+	}{
+		{
+			name:        "without registered session UUID",
+			giveReqVars: nil,
+			checkResult: func(t *testing.T, rr *httptest.ResponseRecorder, b *nullBroadcast.Broadcaster) {
+				assert.Equal(t, http.StatusInternalServerError, rr.Code)
+				assert.JSONEq(t,
+					`{"code":500,"success":false,"message":"cannot extract session UUID"}`, rr.Body.String(),
+				)
+			},
+		},
+		{
+			name:        "emulate storage error",
+			giveReqVars: map[string]string{"sessionUUID": "aa-bb-cc-dd"},
+			setUp: func(s *nullStorage.Storage) {
+				s.Error = errors.New("foo")
+			},
+			checkResult: func(t *testing.T, rr *httptest.ResponseRecorder, b *nullBroadcast.Broadcaster) {
+				assert.Equal(t, http.StatusInternalServerError, rr.Code)
+				assert.JSONEq(t,
+					`{"code":500,"success":false,"message":"cannot read session data from storage: foo"}`, rr.Body.String(),
+				)
+			},
+		},
+		{
+			name:        "emulate 'session was not found'",
+			giveReqVars: map[string]string{"sessionUUID": "aa-bb-cc-dd"},
+			setUp: func(s *nullStorage.Storage) {
+				s.Error = nil
+				s.Boolean = false
+			},
+			checkResult: func(t *testing.T, rr *httptest.ResponseRecorder, b *nullBroadcast.Broadcaster) {
+				assert.Equal(t, http.StatusNotFound, rr.Code)
+				assert.JSONEq(t,
+					`{"code":404,"success":false,"message":"session with UUID aa-bb-cc-dd was not found"}`, rr.Body.String(),
+				)
+			},
+		},
+		{
+			name:        "nil body",
+			giveReqVars: map[string]string{"sessionUUID": "aa-bb-cc-dd"},
+			setUp: func(s *nullStorage.Storage) {
+				s.Error = nil
+				s.SessionData = &storage.SessionData{
+					UUID: "aa-bb-cc-dd",
+					WebHookResponse: storage.WebHookResponse{
+						Content:     "foo",
+						Code:        202,
+						ContentType: "foo/bar",
+					},
+					CreatedAtUnix: 0,
+				}
+				s.RequestData = &storage.RequestData{UUID: "11-22-33-44"}
+			},
+			checkResult: func(t *testing.T, rr *httptest.ResponseRecorder, b *nullBroadcast.Broadcaster) {
+				time.Sleep(time.Millisecond) // goroutine must be done
+
+				assert.Equal(t, 202, rr.Code)
+				assert.Equal(t, "foo", rr.Body.String())
+				assert.Equal(t, "foo/bar", rr.Header().Get("Content-Type"))
+
+				assert.Equal(t, "aa-bb-cc-dd", b.GetLastPublishedChannel())
+				assert.Equal(t, broadcast.RequestRegistered, b.GetLastPublishedEventName())
+				assert.Equal(t, "11-22-33-44", b.GetLastPublishedData())
+			},
+		},
+		{
+			name:        "string body",
+			giveReqVars: map[string]string{"sessionUUID": "aa-bb-cc-dd"},
+			giveBody:    bytes.NewBuffer([]byte(`foo=bar`)),
+			setUp: func(s *nullStorage.Storage) {
+				s.Error = nil
+				s.SessionData = &storage.SessionData{
+					UUID: "aa-bb-cc-dd",
+					WebHookResponse: storage.WebHookResponse{
+						Content: "foo",
+						Code:    202,
+					},
+					CreatedAtUnix: 0,
+				}
+				s.RequestData = &storage.RequestData{UUID: "11-22-33-44"}
+			},
+			checkResult: func(t *testing.T, rr *httptest.ResponseRecorder, b *nullBroadcast.Broadcaster) {
+				time.Sleep(time.Millisecond) // goroutine must be done
+
+				assert.Equal(t, 202, rr.Code)
+				assert.Equal(t, "foo", rr.Body.String())
+
+				assert.Equal(t, "aa-bb-cc-dd", b.GetLastPublishedChannel())
+				assert.Equal(t, broadcast.RequestRegistered, b.GetLastPublishedEventName())
+				assert.Equal(t, "11-22-33-44", b.GetLastPublishedData())
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				req, _  = http.NewRequest(http.MethodPost, "http://testing", tt.giveBody)
+				rr      = httptest.NewRecorder()
+				s       = &nullStorage.Storage{}
+				br      = &nullBroadcast.Broadcaster{}
+				handler = NewHandler(&settings.AppSettings{}, s, br)
+			)
+
+			if tt.giveReqVars != nil {
+				req = mux.SetURLVars(req, tt.giveReqVars)
+			}
+
+			if tt.setUp != nil {
+				tt.setUp(s)
+			}
+
+			handler.ServeHTTP(rr, req)
+
+			tt.checkResult(t, rr, br)
+		})
+	}
 }

--- a/http/webhook/handler_test.go
+++ b/http/webhook/handler_test.go
@@ -1,0 +1,9 @@
+package webhook
+
+import (
+	"testing"
+)
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	t.Skip("Not implemented yet")
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -9,6 +9,9 @@ type AppSettings struct {
 	// Session lifetime (TTL)
 	SessionTTL time.Duration
 
+	// Declared here HTTP header prefixes will be ignored for incoming webhook headers recording
+	IgnoreHeaderPrefixes []string
+
 	// pusher.com key
 	PusherKey string
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

### Added

- Flag `--ignore-header-prefix` for incoming webhook headers ignoring (by prefix)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
