### PR TITLE
Added head method support for the health check endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- `HEAD` method support for the health check endpoints (`/ready`, `/live`) [#204]
+
+[#204]:https://github.com/tarampampam/webhook-tester/issues/204
+
 ## v1.0.1
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ image: ## Build docker image with the app
 frontend: node-install ## Build the frontend
 	docker-compose run $(DC_RUN_ARGS) --no-deps node sh -c 'npm run generate && npm run build'
 
+.PHONY: gen
 gen: ## Run code-generation
 	docker-compose run $(DC_RUN_ARGS) --no-deps app go generate ./...
 

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -136,6 +136,7 @@ paths:
     head:
       tags: [health]
       summary: Readiness probe (HEAD)
+      description: Is an alias for the GET method, but without content in the response body
       operationId: readinessProbeHead
       responses:
         "200": {$ref: '#/components/responses/ServiceHealthy'}
@@ -154,6 +155,7 @@ paths:
     head:
       tags: [health]
       summary: Liveness probe (HEAD)
+      description: Is an alias for the GET method, but without content in the response body
       operationId: livenessProbeHead
       responses:
         "200": {$ref: '#/components/responses/ServiceHealthy'}

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -133,12 +133,28 @@ paths:
         "200": {$ref: '#/components/responses/ServiceHealthy'}
         "503": {$ref: '#/components/responses/ServiceUnhealthy'}
 
+    head:
+      tags: [health]
+      summary: Readiness probe (HEAD)
+      operationId: readinessProbeHead
+      responses:
+        "200": {$ref: '#/components/responses/ServiceHealthy'}
+        "503": {$ref: '#/components/responses/ServiceUnhealthy'}
+
   /live:
     get:
       tags: [health]
       summary: Liveness probe
       description: Is the app alive or dead?
       operationId: livenessProbe
+      responses:
+        "200": {$ref: '#/components/responses/ServiceHealthy'}
+        "503": {$ref: '#/components/responses/ServiceUnhealthy'}
+
+    head:
+      tags: [health]
+      summary: Liveness probe (HEAD)
+      operationId: livenessProbeHead
       responses:
         "200": {$ref: '#/components/responses/ServiceHealthy'}
         "503": {$ref: '#/components/responses/ServiceUnhealthy'}

--- a/internal/http/handlers/api_health.go
+++ b/internal/http/handlers/api_health.go
@@ -27,7 +27,13 @@ func (s *apiHealth) LivenessProbe(c echo.Context) error {
 	return s.makeCheck(c, s.liveChecker)
 }
 
+// LivenessProbeHead is an alias for the LivenessProbe.
+func (s *apiHealth) LivenessProbeHead(c echo.Context) error { return s.LivenessProbe(c) }
+
 // ReadinessProbe returns code 200 if the application is ready to serve traffic.
 func (s *apiHealth) ReadinessProbe(c echo.Context) error {
 	return s.makeCheck(c, s.readyChecker)
 }
+
+// ReadinessProbeHead is an alias for the ReadinessProbe.
+func (s *apiHealth) ReadinessProbeHead(c echo.Context) error { return s.ReadinessProbe(c) }

--- a/internal/pubsub/redis_test.go
+++ b/internal/pubsub/redis_test.go
@@ -141,8 +141,8 @@ func TestRedis_Unsubscribe(t *testing.T) {
 
 			assert.NoError(t, ps.Subscribe("foo", ch1))
 
-			runtime.Gosched()
 			<-time.After(time.Millisecond * 5)
+			runtime.Gosched()
 
 			assert.NoError(t, ps.Subscribe("foo", ch2)) // will be not unsubscribed for a test
 			assert.EqualError(t, ps.Unsubscribe("", ch1), "empty channel name is not allowed")
@@ -153,8 +153,8 @@ func TestRedis_Unsubscribe(t *testing.T) {
 
 			assert.NoError(t, ps.Publish("foo", pubsub.NewRequestRegisteredEvent("bar")))
 
+			<-time.After(time.Millisecond * 50)
 			runtime.Gosched()
-			<-time.After(time.Millisecond * 15)
 
 			assert.Len(t, ch1, 0)
 			assert.Len(t, ch2, 1)

--- a/test/hurl/health/live.hurl
+++ b/test/hurl/health/live.hurl
@@ -5,8 +5,11 @@ HTTP/* 200
 [Asserts]
 bytes count == 0
 
-# --- Head request should fails
+# --- Head request
 
 HEAD http://{{ host }}:{{ port }}/live
 
-HTTP/* 404
+HTTP/* 200
+
+[Asserts]
+bytes count == 0

--- a/test/hurl/health/ready.hurl
+++ b/test/hurl/health/ready.hurl
@@ -5,8 +5,11 @@ HTTP/* 200
 [Asserts]
 bytes count == 0
 
-# --- Head request should fails
+# --- Head request
 
 HEAD http://{{ host }}:{{ port }}/ready
 
-HTTP/* 404
+HTTP/* 200
+
+[Asserts]
+bytes count == 0


### PR DESCRIPTION
## Description

### Added

- `HEAD` method support for the health check endpoints (`/ready`, `/live`)

Closes #204

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [x] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
