### PR TITLE
fix(storage): prevent nil-pointer dereference on auto-created sessions

### DIFF
--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -155,8 +155,8 @@ func (s *InMemory) NewSession(ctx context.Context, session Session, id ...string
 		// check if the session with the specified ID already exists
 		if data, ok := s.sessions.Load(sID); ok {
 			return "", fmt.Errorf("session %s already exists", sID)
-		} else {
-			// check if the session with the specified ID has expired
+		} else if data != nil {
+			// check if the session with the specified ID has expired if it exists
 			data.Lock()
 			expiresAt := data.session.ExpiresAt
 			data.Unlock()


### PR DESCRIPTION
## Description

in combination with `--auto-create-sessions` options, the expiry check can not be performed since we get nil for the session on the initial incoming webhook

## Checklist

- [ x ] My code adheres to the style guidelines of this project
- [ x ] I have conducted a self-review of my code
- [ x ] I have added comments to my code, especially in areas that may be difficult to understand

