### PR TITLE
fix(storage): Make unlimited requests count great again

### DIFF
--- a/internal/storage/fs.go
+++ b/internal/storage/fs.go
@@ -432,7 +432,7 @@ func (s *FS) DeleteSession(ctx context.Context, sID string) error {
 	return s.withLock(false, func() error { return os.RemoveAll(s.sessionDir(sID)) })
 }
 
-func (s *FS) NewRequest(ctx context.Context, sID string, r Request) (rID string, _ error) { //nolint:funlen
+func (s *FS) NewRequest(ctx context.Context, sID string, r Request) (rID string, _ error) { //nolint:funlen,gocyclo
 	if err := s.isOpenAndNotDone(ctx); err != nil {
 		return "", err
 	}

--- a/internal/storage/fs.go
+++ b/internal/storage/fs.go
@@ -488,7 +488,7 @@ func (s *FS) NewRequest(ctx context.Context, sID string, r Request) (rID string,
 		return "", err
 	}
 
-	{ // limit stored requests count
+	if s.maxRequests > 0 { // limit stored requests count
 		list, lErr := s.listRequestFiles(sID)
 		if lErr != nil {
 			return "", lErr

--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -258,7 +258,7 @@ func (s *InMemory) NewRequest(ctx context.Context, sID string, r Request) (rID s
 
 	data.requests.Store(rID, r)
 
-	{ // limit stored requests count
+	if s.maxRequests > 0 { // limit stored requests count
 		type rq struct { // a runtime representation of the request, used for sorting
 			id string
 			ts int64

--- a/internal/storage/redis.go
+++ b/internal/storage/redis.go
@@ -235,7 +235,7 @@ func (s *Redis) NewRequest(ctx context.Context, sID string, r Request) (rID stri
 	}
 
 	// if we have too many requests - remove unnecessary
-	if len(ids) > int(s.maxRequests) {
+	if s.maxRequests > 0 && len(ids) > int(s.maxRequests) {
 		if _, err := s.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 			for _, id := range ids[:len(ids)-int(s.maxRequests)] {
 				pipe.ZRem(ctx, s.requestsKey(sID), id)


### PR DESCRIPTION


## Description

Updated request count limit checks in FS, InMemory, and Redis storage implementations to ensure they only execute when maxRequests is greater than zero. This change enhances code clarity and prevents unnecessary operations when the limit is not set.

Fixes #645
