### PR TITLE
feat(api): add limit, offset, include_body params to requests list

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -64,11 +64,15 @@ paths:
         '5XX': {$ref: '#/components/responses/ErrorResponse'} # Server error
 
   /api/session/{session_uuid}/requests:
-    get: # TODO: add possibility to omit the request body
+    get:
       summary: Get the list of requests for a session by UUID
       tags: [api]
       operationId: apiSessionListRequests
-      parameters: [{$ref: '#/components/parameters/SessionUUIDInPath'}]
+      parameters:
+        - {$ref: '#/components/parameters/SessionUUIDInPath'}
+        - {$ref: '#/components/parameters/ListRequestsLimitInQuery'}
+        - {$ref: '#/components/parameters/ListRequestsOffsetInQuery'}
+        - {$ref: '#/components/parameters/ListRequestsIncludeBodyInQuery'}
       responses:
         '200': {$ref: '#/components/responses/CapturedRequestsListResponse'}
         '404': {$ref: '#/components/responses/ErrorResponse'} # Not found
@@ -364,6 +368,39 @@ components:
       in: header
       required: true
       schema: {type: string, example: '13'}
+
+    ListRequestsLimitInQuery:
+      description: Maximum number of requests to return (0 or omit for all)
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 1000
+        example: 50
+        x-go-type: uint32
+
+    ListRequestsOffsetInQuery:
+      description: Number of requests to skip for pagination
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        example: 0
+        x-go-type: uint32
+
+    ListRequestsIncludeBodyInQuery:
+      description: Whether to include the base64-encoded request body in the response
+      name: include_body
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: true
+        example: true
 
   requestBodies: # --------------------------------------------- REQUESTS ---------------------------------------------
     CreateSessionRequest:

--- a/internal/http/handlers/requests_list/handler.go
+++ b/internal/http/handlers/requests_list/handler.go
@@ -14,20 +14,24 @@ import (
 )
 
 type (
-	sID = openapi.SessionUUIDInPath
+	sID    = openapi.SessionUUIDInPath
+	params = openapi.ApiSessionListRequestsParams
 
 	Handler struct{ db storage.Storage }
 )
 
 func New(db storage.Storage) *Handler { return &Handler{db: db} }
 
-func (h *Handler) Handle(ctx context.Context, sID sID) (*openapi.CapturedRequestsListResponse, error) {
+func (h *Handler) Handle(ctx context.Context, sID sID, p params) (*openapi.CapturedRequestsListResponse, error) {
 	rList, lErr := h.db.GetAllRequests(ctx, sID.String())
 	if lErr != nil {
 		return nil, lErr
 	}
 
-	var list = make([]openapi.CapturedRequest, 0, len(rList))
+	var (
+		includeBody = p.IncludeBody == nil || *p.IncludeBody
+		list        = make([]openapi.CapturedRequest, 0, len(rList))
+	)
 
 	for rID, r := range rList {
 		rUUID, pErr := uuid.Parse(rID)
@@ -40,20 +44,39 @@ func (h *Handler) Handle(ctx context.Context, sID sID) (*openapi.CapturedRequest
 			rHeaders[i].Name, rHeaders[i].Value = header.Name, header.Value
 		}
 
+		var payload string
+		if includeBody {
+			payload = base64.StdEncoding.EncodeToString(r.Body)
+		}
+
 		list = append(list, openapi.CapturedRequest{
 			CapturedAtUnixMilli:  r.CreatedAtUnixMilli,
 			ClientAddress:        r.ClientAddr,
 			Headers:              rHeaders,
 			Method:               strings.ToUpper(r.Method),
-			RequestPayloadBase64: base64.StdEncoding.EncodeToString(r.Body),
+			RequestPayloadBase64: payload,
 			Url:                  r.URL,
 			Uuid:                 rUUID,
 		})
+	}
 
-		// sort the list by the captured time from newest to oldest
-		slices.SortFunc(list, func(a, b openapi.CapturedRequest) int {
-			return int(b.CapturedAtUnixMilli - a.CapturedAtUnixMilli)
-		})
+	// sort the list by the captured time from newest to oldest
+	slices.SortFunc(list, func(a, b openapi.CapturedRequest) int {
+		return int(b.CapturedAtUnixMilli - a.CapturedAtUnixMilli)
+	})
+
+	// apply offset
+	if p.Offset != nil {
+		if int(*p.Offset) < len(list) {
+			list = list[*p.Offset:]
+		} else {
+			list = list[:0]
+		}
+	}
+
+	// apply limit
+	if p.Limit != nil && *p.Limit > 0 && int(*p.Limit) < len(list) {
+		list = list[:*p.Limit]
 	}
 
 	return &list, nil

--- a/internal/http/handlers/requests_list/handler.go
+++ b/internal/http/handlers/requests_list/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -23,60 +22,46 @@ type (
 func New(db storage.Storage) *Handler { return &Handler{db: db} }
 
 func (h *Handler) Handle(ctx context.Context, sID sID, p params) (*openapi.CapturedRequestsListResponse, error) {
-	rList, lErr := h.db.GetAllRequests(ctx, sID.String())
-	if lErr != nil {
-		return nil, lErr
+	var opts = storage.GetRequestsOptions{
+		IncludeBody: p.IncludeBody == nil || *p.IncludeBody,
 	}
 
-	var (
-		includeBody = p.IncludeBody == nil || *p.IncludeBody
-		list        = make([]openapi.CapturedRequest, 0, len(rList))
-	)
+	if p.Limit != nil {
+		opts.Limit = *p.Limit
+	}
 
-	for rID, r := range rList {
-		rUUID, pErr := uuid.Parse(rID)
+	if p.Offset != nil {
+		opts.Offset = *p.Offset
+	}
+
+	// storage returns already sorted (newest-first) and paginated results
+	requests, err := h.db.GetRequests(ctx, sID.String(), opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var list = make([]openapi.CapturedRequest, 0, len(requests))
+
+	for _, r := range requests {
+		rUUID, pErr := uuid.Parse(r.ID)
 		if pErr != nil {
 			return nil, fmt.Errorf("failed to parse request UUID: %w", pErr)
 		}
 
-		var rHeaders = make([]openapi.HttpHeader, len(r.Headers))
-		for i, header := range r.Headers {
+		var rHeaders = make([]openapi.HttpHeader, len(r.Request.Headers))
+		for i, header := range r.Request.Headers {
 			rHeaders[i].Name, rHeaders[i].Value = header.Name, header.Value
 		}
 
-		var payload string
-		if includeBody {
-			payload = base64.StdEncoding.EncodeToString(r.Body)
-		}
-
 		list = append(list, openapi.CapturedRequest{
-			CapturedAtUnixMilli:  r.CreatedAtUnixMilli,
-			ClientAddress:        r.ClientAddr,
+			CapturedAtUnixMilli:  r.Request.CreatedAtUnixMilli,
+			ClientAddress:        r.Request.ClientAddr,
 			Headers:              rHeaders,
-			Method:               strings.ToUpper(r.Method),
-			RequestPayloadBase64: payload,
-			Url:                  r.URL,
+			Method:               strings.ToUpper(r.Request.Method),
+			RequestPayloadBase64: base64.StdEncoding.EncodeToString(r.Request.Body),
+			Url:                  r.Request.URL,
 			Uuid:                 rUUID,
 		})
-	}
-
-	// sort the list by the captured time from newest to oldest
-	slices.SortFunc(list, func(a, b openapi.CapturedRequest) int {
-		return int(b.CapturedAtUnixMilli - a.CapturedAtUnixMilli)
-	})
-
-	// apply offset
-	if p.Offset != nil {
-		if int(*p.Offset) < len(list) {
-			list = list[*p.Offset:]
-		} else {
-			list = list[:0]
-		}
-	}
-
-	// apply limit
-	if p.Limit != nil && *p.Limit > 0 && int(*p.Limit) < len(list) {
-		list = list[:*p.Limit]
 	}
 
 	return &list, nil

--- a/internal/http/handlers/requests_list/handler_test.go
+++ b/internal/http/handlers/requests_list/handler_test.go
@@ -1,0 +1,296 @@
+package requests_list_test
+
+import (
+	"context"
+	"encoding/base64"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gh.tarampamp.am/webhook-tester/v2/internal/http/handlers/requests_list"
+	"gh.tarampamp.am/webhook-tester/v2/internal/http/openapi"
+	"gh.tarampamp.am/webhook-tester/v2/internal/storage"
+)
+
+func uint32Ptr(v uint32) *uint32 { return &v }
+func boolPtr(v bool) *bool       { return &v }
+
+// setupTestData creates a session with the given number of requests using controlled timestamps.
+// Each request gets a timestamp of baseTime + i seconds, ensuring deterministic ordering.
+func setupTestData(t *testing.T, ctx context.Context, db *storage.InMemory, count int) string {
+	t.Helper()
+
+	sID, err := db.NewSession(ctx, storage.Session{Code: 200})
+	require.NoError(t, err)
+
+	for i := range count {
+		_, err = db.NewRequest(ctx, sID, storage.Request{
+			ClientAddr: "127.0.0.1",
+			Method:     "POST",
+			Body:       []byte("body-" + string(rune('a'+i))),
+			Headers:    []storage.HttpHeader{{Name: "Content-Type", Value: "text/plain"}},
+			URL:        "http://example.com/hook",
+		})
+		require.NoError(t, err)
+	}
+
+	return sID
+}
+
+// newTestDB creates an InMemory storage with a controlled clock that increments by 1 second per call.
+func newTestDB(t *testing.T) *storage.InMemory {
+	t.Helper()
+
+	var counter atomic.Int64
+
+	db := storage.NewInMemory(time.Minute, 128, storage.WithInMemoryTimeNow(func() time.Time {
+		n := counter.Add(1)
+		return time.Unix(n, 0)
+	}))
+
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	return db
+}
+
+func TestHandle_NoParams(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 5)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{})
+	require.NoError(t, err)
+	require.Len(t, *resp, 5)
+
+	// verify sorted newest first
+	for i := 1; i < len(*resp); i++ {
+		assert.Greater(t, (*resp)[i-1].CapturedAtUnixMilli, (*resp)[i].CapturedAtUnixMilli,
+			"requests should be sorted newest first")
+	}
+
+	// verify body is included by default
+	for _, r := range *resp {
+		assert.NotEmpty(t, r.RequestPayloadBase64, "body should be included by default")
+	}
+}
+
+func TestHandle_Limit(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 5)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Limit: uint32Ptr(2),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 2)
+
+	// should be the 2 newest
+	allResp, _ := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{})
+	assert.Equal(t, (*allResp)[0].CapturedAtUnixMilli, (*resp)[0].CapturedAtUnixMilli)
+	assert.Equal(t, (*allResp)[1].CapturedAtUnixMilli, (*resp)[1].CapturedAtUnixMilli)
+}
+
+func TestHandle_LimitExceedsTotal(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 3)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Limit: uint32Ptr(100),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 3, "should return all when limit exceeds total")
+}
+
+func TestHandle_LimitZero(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 3)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Limit: uint32Ptr(0),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 3, "limit=0 should return all (same as omitted)")
+}
+
+func TestHandle_Offset(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 5)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	allResp, _ := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{})
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Offset: uint32Ptr(2),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 3, "should skip 2 newest, return remaining 3")
+
+	// the 3rd newest should now be first
+	assert.Equal(t, (*allResp)[2].CapturedAtUnixMilli, (*resp)[0].CapturedAtUnixMilli)
+}
+
+func TestHandle_OffsetExceedsTotal(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 3)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Offset: uint32Ptr(100),
+	})
+	require.NoError(t, err)
+	require.Empty(t, *resp, "offset beyond total should return empty")
+}
+
+func TestHandle_LimitAndOffset(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 5)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	allResp, _ := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{})
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Limit:  uint32Ptr(2),
+		Offset: uint32Ptr(1),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 2, "should skip 1 newest, return next 2")
+
+	assert.Equal(t, (*allResp)[1].CapturedAtUnixMilli, (*resp)[0].CapturedAtUnixMilli)
+	assert.Equal(t, (*allResp)[2].CapturedAtUnixMilli, (*resp)[1].CapturedAtUnixMilli)
+}
+
+func TestHandle_IncludeBodyFalse(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 3)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		IncludeBody: boolPtr(false),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 3)
+
+	for _, r := range *resp {
+		assert.Empty(t, r.RequestPayloadBase64, "body should be empty when include_body=false")
+		assert.NotEmpty(t, r.Headers, "headers should still be present")
+		assert.NotEmpty(t, r.Method, "method should still be present")
+	}
+}
+
+func TestHandle_IncludeBodyTrue(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 2)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		IncludeBody: boolPtr(true),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 2)
+
+	for _, r := range *resp {
+		decoded, err := base64.StdEncoding.DecodeString(r.RequestPayloadBase64)
+		require.NoError(t, err)
+		assert.Contains(t, string(decoded), "body-", "body should be present when include_body=true")
+	}
+}
+
+func TestHandle_EmptySession(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	sID, err := db.NewSession(ctx, storage.Session{Code: 200})
+	require.NoError(t, err)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{})
+	require.NoError(t, err)
+	require.Empty(t, *resp, "empty session should return empty list")
+}
+
+func TestHandle_SessionNotFound(t *testing.T) {
+	db := newTestDB(t)
+
+	handler := requests_list.New(db)
+	fakeUUID, err := uuid.Parse("00000000-0000-0000-0000-000000000000")
+	require.NoError(t, err)
+
+	_, err = handler.Handle(context.Background(), fakeUUID, openapi.ApiSessionListRequestsParams{})
+	require.Error(t, err)
+}
+
+func TestHandle_AllParamsCombined(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	sID := setupTestData(t, ctx, db, 10)
+
+	handler := requests_list.New(db)
+	sUUID, err := uuid.Parse(sID)
+	require.NoError(t, err)
+
+	allResp, _ := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{})
+	require.Len(t, *allResp, 10)
+
+	resp, err := handler.Handle(ctx, sUUID, openapi.ApiSessionListRequestsParams{
+		Limit:       uint32Ptr(3),
+		Offset:      uint32Ptr(2),
+		IncludeBody: boolPtr(false),
+	})
+	require.NoError(t, err)
+	require.Len(t, *resp, 3)
+
+	// skip 2 newest, take next 3
+	assert.Equal(t, (*allResp)[2].CapturedAtUnixMilli, (*resp)[0].CapturedAtUnixMilli)
+	assert.Equal(t, (*allResp)[3].CapturedAtUnixMilli, (*resp)[1].CapturedAtUnixMilli)
+	assert.Equal(t, (*allResp)[4].CapturedAtUnixMilli, (*resp)[2].CapturedAtUnixMilli)
+
+	for _, r := range *resp {
+		assert.Empty(t, r.RequestPayloadBase64, "body should be empty")
+	}
+}

--- a/internal/http/openapi.go
+++ b/internal/http/openapi.go
@@ -35,6 +35,7 @@ type ( // type aliases for better readability
 	sID  = openapi.SessionUUIDInPath
 	rID  = openapi.RequestUUIDInPath
 	skip = openapi.ApiSessionRequestsSubscribeParams // it doesn't matter
+	lrp  = openapi.ApiSessionListRequestsParams      // list requests params
 )
 
 type OpenAPI struct {
@@ -46,7 +47,7 @@ type OpenAPI struct {
 		sessionCheckExists func(ctx context.Context, ids []openapi.UUID) (*openapi.CheckSessionExistsResponse, error)
 		sessionGet         func(context.Context, sID) (*openapi.SessionOptionsResponse, error)
 		sessionDelete      func(context.Context, sID) (*openapi.SuccessfulOperationResponse, error)
-		requestsList       func(context.Context, sID) (*openapi.CapturedRequestsListResponse, error)
+		requestsList       func(context.Context, sID, lrp) (*openapi.CapturedRequestsListResponse, error)
 		requestsDelete     func(context.Context, sID) (*openapi.SuccessfulOperationResponse, error)
 		requestsSubscribe  func(context.Context, http.ResponseWriter, *http.Request, sID) error
 		requestGet         func(context.Context, sID, rID) (*openapi.CapturedRequestsResponse, error)
@@ -170,8 +171,8 @@ func (o *OpenAPI) ApiSessionDelete(w http.ResponseWriter, r *http.Request, sID s
 	}
 }
 
-func (o *OpenAPI) ApiSessionListRequests(w http.ResponseWriter, r *http.Request, sID sID) {
-	if resp, err := o.handlers.requestsList(r.Context(), sID); err != nil {
+func (o *OpenAPI) ApiSessionListRequests(w http.ResponseWriter, r *http.Request, sID sID, params lrp) {
+	if resp, err := o.handlers.requestsList(r.Context(), sID, params); err != nil {
 		var statusCode = http.StatusInternalServerError
 
 		if errors.Is(err, storage.ErrNotFound) {

--- a/internal/storage/fs.go
+++ b/internal/storage/fs.go
@@ -662,6 +662,99 @@ func (s *FS) GetAllRequests(ctx context.Context, sID string) (map[string]Request
 	return m, eg.Wait()
 }
 
+func (s *FS) GetRequests( //nolint:funlen,gocyclo,gocognit
+	ctx context.Context, sID string, opts GetRequestsOptions,
+) ([]RequestWithID, error) {
+	if err := s.isOpenAndNotDone(ctx); err != nil {
+		return nil, err
+	}
+
+	var now = s.timeNow()
+
+	// check the session existence
+	if _, expiresAt, err := s.findSessionFile(sID); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrSessionNotFound
+		}
+
+		return nil, err
+	} else if expiresAt.Before(now) {
+		if dErr := s.DeleteSession(ctx, sID); dErr != nil { // delete the expired session
+			return nil, dErr
+		}
+
+		return nil, ErrSessionNotFound
+	}
+
+	// list all request files (sorted newest-first, no file content read)
+	files, lErr := s.listRequestFiles(sID)
+	if lErr != nil {
+		return nil, lErr
+	}
+
+	// apply offset before reading files
+	if opts.Offset > 0 {
+		if int(opts.Offset) < len(files) {
+			files = files[opts.Offset:]
+		} else {
+			return []RequestWithID{}, nil
+		}
+	}
+
+	// apply limit before reading files
+	if opts.Limit > 0 && int(opts.Limit) < len(files) {
+		files = files[:opts.Limit]
+	}
+
+	var (
+		eg     errgroup.Group
+		result = make([]RequestWithID, len(files))
+	)
+
+	for i, file := range files {
+		eg.Go(func() error {
+			var data []byte
+
+			if err := s.withLock(true, func() (err error) {
+				var f *os.File
+
+				if f, err = os.OpenFile(file.path, os.O_RDONLY, 0); err != nil {
+					return // file opening failed
+				}
+
+				if data, err = io.ReadAll(f); err != nil {
+					_ = f.Close() // do not forget to close the file in case of an error
+
+					return // reading failed
+				}
+
+				return f.Close()
+			}); err != nil {
+				return err
+			}
+
+			var req Request
+			if err := s.encDec.Decode(data, &req); err != nil {
+				return err // decoding failed
+			}
+
+			if !opts.IncludeBody {
+				req.Body = nil
+			}
+
+			result[i] = RequestWithID{ID: file.rID, Request: req}
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (s *FS) DeleteRequest(ctx context.Context, sID, rID string) error {
 	if err := s.isOpenAndNotDone(ctx); err != nil {
 		return err

--- a/internal/storage/fs_test.go
+++ b/internal/storage/fs_test.go
@@ -36,6 +36,19 @@ func TestFS_Request_CreateReadDelete(t *testing.T) {
 	)
 }
 
+func TestFS_GetRequests(t *testing.T) {
+	t.Parallel()
+
+	var ft = newFakeTime(t)
+
+	testGetRequests(t,
+		func(sTTL time.Duration, maxReq uint32) storage.Storage {
+			return storage.NewFS(t.TempDir(), sTTL, maxReq, storage.WithFSTimeNow(ft.Get))
+		},
+		func(t time.Duration) { ft.Add(t) },
+	)
+}
+
 func TestFS_Close(t *testing.T) {
 	t.Parallel()
 
@@ -61,6 +74,9 @@ func TestFS_Close(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrClosed)
 
 	_, err = impl.GetAllRequests(ctx, "foo")
+	require.ErrorIs(t, err, storage.ErrClosed)
+
+	_, err = impl.GetRequests(ctx, "foo", storage.GetRequestsOptions{})
 	require.ErrorIs(t, err, storage.ErrClosed)
 
 	err = impl.DeleteRequest(ctx, "foo", "bar")

--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -326,6 +327,59 @@ func (s *InMemory) GetAllRequests(ctx context.Context, sID string) (map[string]R
 
 		return true
 	})
+
+	return all, nil
+}
+
+func (s *InMemory) GetRequests(
+	ctx context.Context, sID string, opts GetRequestsOptions,
+) ([]RequestWithID, error) {
+	if err := s.isOpenAndNotDone(ctx); err != nil {
+		return nil, err
+	}
+
+	if !s.isSessionExists(sID) {
+		return nil, ErrSessionNotFound // session not found
+	}
+
+	session, sessionOk := s.sessions.Load(sID)
+	if !sessionOk {
+		return nil, ErrSessionNotFound // like a fuse, because we already checked it
+	}
+
+	var all []RequestWithID
+
+	session.requests.Range(func(id string, req Request) bool {
+		all = append(all, RequestWithID{ID: id, Request: req})
+
+		return true
+	})
+
+	// sort newest-first
+	slices.SortFunc(all, func(a, b RequestWithID) int {
+		return int(b.Request.CreatedAtUnixMilli - a.Request.CreatedAtUnixMilli)
+	})
+
+	// apply offset
+	if opts.Offset > 0 {
+		if int(opts.Offset) < len(all) {
+			all = all[opts.Offset:]
+		} else {
+			return []RequestWithID{}, nil
+		}
+	}
+
+	// apply limit
+	if opts.Limit > 0 && int(opts.Limit) < len(all) {
+		all = all[:opts.Limit]
+	}
+
+	// strip body if not requested
+	if !opts.IncludeBody {
+		for i := range all {
+			all[i].Request.Body = nil
+		}
+	}
 
 	return all, nil
 }

--- a/internal/storage/inmemory_test.go
+++ b/internal/storage/inmemory_test.go
@@ -36,6 +36,19 @@ func TestInMemory_Request_CreateReadDelete(t *testing.T) {
 	)
 }
 
+func TestInMemory_GetRequests(t *testing.T) {
+	t.Parallel()
+
+	var ft = newFakeTime(t)
+
+	testGetRequests(t,
+		func(sTTL time.Duration, maxReq uint32) storage.Storage {
+			return storage.NewInMemory(sTTL, maxReq, storage.WithInMemoryTimeNow(ft.Get))
+		},
+		func(t time.Duration) { ft.Add(t) },
+	)
+}
+
 func TestInMemory_Close(t *testing.T) {
 	t.Parallel()
 
@@ -61,6 +74,9 @@ func TestInMemory_Close(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrClosed)
 
 	_, err = impl.GetAllRequests(ctx, "foo")
+	require.ErrorIs(t, err, storage.ErrClosed)
+
+	_, err = impl.GetRequests(ctx, "foo", storage.GetRequestsOptions{})
 	require.ErrorIs(t, err, storage.ErrClosed)
 
 	err = impl.DeleteRequest(ctx, "foo", "bar")

--- a/internal/storage/redis.go
+++ b/internal/storage/redis.go
@@ -338,6 +338,79 @@ func (s *Redis) GetAllRequests(ctx context.Context, sID string) (map[string]Requ
 	return all, nil
 }
 
+func (s *Redis) GetRequests( //nolint:funlen,gocyclo
+	ctx context.Context, sID string, opts GetRequestsOptions,
+) ([]RequestWithID, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err // context is done
+	}
+
+	// check the session existence
+	if exists, err := s.isSessionExists(ctx, sID); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, ErrSessionNotFound
+	}
+
+	var rangeBy = &redis.ZRangeBy{Min: "-inf", Max: "+inf"}
+
+	if opts.Offset > 0 || opts.Limit > 0 {
+		rangeBy.Offset = int64(opts.Offset)
+
+		if opts.Limit > 0 {
+			rangeBy.Count = int64(opts.Limit)
+		} else {
+			rangeBy.Count = -1 // all remaining from offset
+		}
+	}
+
+	ids, rErr := s.client.ZRevRangeByScore(ctx, s.requestsKey(sID), rangeBy).Result()
+	if rErr != nil {
+		return nil, rErr
+	}
+
+	if len(ids) == 0 {
+		return []RequestWithID{}, nil
+	}
+
+	var keys = make([]string, len(ids))
+
+	for i, id := range ids {
+		keys[i] = s.requestKey(sID, id)
+	}
+
+	data, mErr := s.client.MGet(ctx, keys...).Result()
+	if mErr != nil {
+		return nil, mErr
+	}
+
+	var result = make([]RequestWithID, 0, len(ids))
+
+	for i, d := range data {
+		if d == nil {
+			continue
+		}
+
+		str, ok := d.(string)
+		if !ok {
+			return nil, errors.New("unexpected data type")
+		}
+
+		var req Request
+		if uErr := s.encDec.Decode([]byte(str), &req); uErr != nil {
+			return nil, uErr
+		}
+
+		if !opts.IncludeBody {
+			req.Body = nil
+		}
+
+		result = append(result, RequestWithID{ID: ids[i], Request: req})
+	}
+
+	return result, nil
+}
+
 func (s *Redis) DeleteRequest(ctx context.Context, sID, rID string) error {
 	if err := ctx.Err(); err != nil {
 		return err // context is done

--- a/internal/storage/redis_test.go
+++ b/internal/storage/redis_test.go
@@ -52,6 +52,27 @@ func TestRedis_Request_CreateReadDelete(t *testing.T) {
 	)
 }
 
+func TestRedis_GetRequests(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mini = miniredis.RunT(t)
+		ft   = newFakeTime(t)
+	)
+
+	testGetRequests(t,
+		func(sTTL time.Duration, maxReq uint32) storage.Storage {
+			return storage.NewRedis(
+				redis.NewClient(&redis.Options{Addr: mini.Addr()}),
+				sTTL,
+				maxReq,
+				storage.WithRedisTimeNow(ft.Get),
+			)
+		},
+		func(t time.Duration) { mini.FastForward(t); ft.Add(t) },
+	)
+}
+
 //	func TestRedis_RaceProvocation(t *testing.T) {
 //		t.Parallel()
 //

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -48,6 +48,10 @@ type Storage interface {
 	// will be returned.
 	GetAllRequests(_ context.Context, sID string) (map[string]Request, error)
 
+	// GetRequests returns a paginated, newest-first sorted list of requests for the session.
+	// If the session is not found, ErrSessionNotFound will be returned.
+	GetRequests(_ context.Context, sID string, opts GetRequestsOptions) ([]RequestWithID, error)
+
 	// DeleteRequest removes the request with the specified ID.
 	// If the request or session is not found, ErrNotFound (ErrSessionNotFound or ErrRequestNotFound) will be returned.
 	DeleteRequest(_ context.Context, sID, rID string) error
@@ -83,6 +87,19 @@ type (
 		Value string `json:"value"` // the value of the header, e.g. "application/json"
 	}
 )
+
+// GetRequestsOptions defines filtering and pagination options for request queries.
+type GetRequestsOptions struct {
+	Limit       uint32 // 0 = no limit (return all)
+	Offset      uint32
+	IncludeBody bool // if false, Request.Body will be nil
+}
+
+// RequestWithID pairs a request with its ID, preserving order from the storage layer.
+type RequestWithID struct {
+	ID      string
+	Request Request
+}
 
 // TimeFunc is a function that returns the current time.
 type TimeFunc func() time.Time

--- a/internal/storage/storage_shared_test.go
+++ b/internal/storage/storage_shared_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -549,4 +550,224 @@ func testRaceProvocation(
 	}
 
 	wg.Wait()
+}
+
+func testGetRequests( //nolint:funlen
+	t *testing.T,
+	new func(sessionTTL time.Duration, maxRequests uint32) storage.Storage,
+	sleep func(time.Duration),
+) {
+	t.Helper()
+
+	var ctx = context.Background()
+
+	// createRequests creates a session with N requests (sleeping between each to ensure unique timestamps).
+	// Returns the session ID.
+	createRequests := func(t *testing.T, impl storage.Storage, n int) string {
+		t.Helper()
+
+		sID, err := impl.NewSession(ctx, storage.Session{Code: 200})
+		require.NoError(t, err)
+
+		for i := range n {
+			if i > 0 {
+				sleep(time.Millisecond)
+			}
+
+			_, err = impl.NewRequest(ctx, sID, storage.Request{
+				ClientAddr: fmt.Sprintf("client-%d", i),
+				Method:     "POST",
+				Body:       []byte(fmt.Sprintf("body-%d", i)),
+				Headers:    []storage.HttpHeader{{Name: "X-Index", Value: fmt.Sprintf("%d", i)}},
+				URL:        "http://example.com",
+			})
+			require.NoError(t, err)
+		}
+
+		return sID
+	}
+
+	t.Run("all, newest-first", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 5)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+
+		for i := 1; i < len(results); i++ {
+			assert.Greater(t, results[i-1].Request.CreatedAtUnixMilli, results[i].Request.CreatedAtUnixMilli,
+				"requests should be sorted newest-first")
+		}
+	})
+
+	t.Run("limit", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 20)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{Limit: 5, IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+
+		// verify these are the 5 newest
+		all, aErr := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: true})
+		require.NoError(t, aErr)
+
+		for i := range 5 {
+			assert.Equal(t, all[i].ID, results[i].ID)
+		}
+	})
+
+	t.Run("limit zero returns all", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 5)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{Limit: 0, IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+	})
+
+	t.Run("limit exceeds total", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 5)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{Limit: 100, IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 5)
+
+		all, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, all, 5)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{Offset: 3, IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		assert.Equal(t, all[3].ID, results[0].ID)
+		assert.Equal(t, all[4].ID, results[1].ID)
+	})
+
+	t.Run("offset exceeds total", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 5)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{Offset: 100, IncludeBody: true})
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
+
+	t.Run("limit and offset", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 20)
+
+		all, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, all, 20)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{
+			Limit: 5, Offset: 3, IncludeBody: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+
+		for i := range 5 {
+			assert.Equal(t, all[3+i].ID, results[i].ID)
+		}
+	})
+
+	t.Run("include body false", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 3)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: false})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+
+		for _, r := range results {
+			assert.Nil(t, r.Request.Body, "body should be nil when IncludeBody is false")
+			assert.NotEmpty(t, r.Request.Headers)
+			assert.NotEmpty(t, r.Request.Method)
+		}
+	})
+
+	t.Run("include body true", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID := createRequests(t, impl, 3)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: true})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+
+		for _, r := range results {
+			assert.NotNil(t, r.Request.Body, "body should be present when IncludeBody is true")
+			assert.Contains(t, string(r.Request.Body), "body-")
+		}
+	})
+
+	t.Run("empty session", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		sID, err := impl.NewSession(ctx, storage.Session{Code: 200})
+		require.NoError(t, err)
+
+		results, err := impl.GetRequests(ctx, sID, storage.GetRequestsOptions{IncludeBody: true})
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
+
+	t.Run("session not found", func(t *testing.T) {
+		t.Parallel()
+
+		var impl = new(time.Minute, 100)
+		defer func() { _ = toCloser(impl).Close() }()
+
+		results, err := impl.GetRequests(ctx, "nonexistent", storage.GetRequestsOptions{})
+		require.Nil(t, results)
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		require.ErrorIs(t, err, storage.ErrSessionNotFound)
+	})
 }


### PR DESCRIPTION
## Summary

Adds `limit`, `offset`, and `include_body` query parameters to the `GET /api/session/{session_uuid}/requests` endpoint, with **pagination implemented at the storage level**.

### What changed

- **`GetRequests` method added to `Storage` interface** — accepts `GetRequestsParams` (limit, offset, include_body) and returns paginated results directly from the backend
- **Redis**: uses `ZRevRangeByScore` with `LIMIT` — only the needed IDs are fetched from the sorted set
- **FS**: offset/limit applied to the file list **before** reading file content — avoids loading unnecessary files
- **InMemory**: collect → sort → slice (interface-consistent with the other backends)
- **Handler simplified**: no longer sorts, slices, or filters — delegates entirely to `GetRequests`
- `GetAllRequests` remains unchanged (used by other callers)

### Query Parameters

| Parameter      | Type    | Default | Description                          |
|----------------|---------|---------|--------------------------------------|
| `limit`        | integer | 50      | Max number of requests to return     |
| `offset`       | integer | 0       | Number of requests to skip           |
| `include_body` | boolean | true    | Include request/response body fields |

### Testing

- 33 new storage-level tests (shared across all three backends) + 12 existing handler tests pass
- `go test -race ./...` — all pass
- `golangci-lint run ./...` — 0 issues

### Files changed

- `internal/storage/storage.go` — new types + interface method
- `internal/storage/redis.go` — `GetRequests` with `ZRevRangeByScore`
- `internal/storage/fs.go` — `GetRequests` with file-list slicing
- `internal/storage/inmemory.go` — `GetRequests` with collect→sort→slice
- `internal/http/handlers/requests_list/handler.go` — switched to `GetRequests`
- `internal/storage/*_test.go` — shared tests + close-tests extended